### PR TITLE
Add per-page metadata

### DIFF
--- a/app/(pages)/about/page.tsx
+++ b/app/(pages)/about/page.tsx
@@ -3,6 +3,12 @@ import AboutSofgent from "@/app/components/about/aboutSofGent";
 import AboutFunFact from "@/app/components/about/funFact";
 import AboutTeam from "@/app/components/about/teamMembers";
 import BreadCrumb from "@components/common/BreadCrumb";
+import getPageMeta from "@/app/utils/getPageMeta";
+import type { Metadata } from "next";
+
+export function generateMetadata(): Metadata {
+   return getPageMeta("/about");
+}
 
 export default function About() {
    return (

--- a/app/(pages)/blog/page.tsx
+++ b/app/(pages)/blog/page.tsx
@@ -2,6 +2,12 @@ import BlogCard from "@/app/components/common/BlogCard";
 import BreadCrumb from "@/app/components/common/BreadCrumb";
 import keystaticConfig from "@/keystatic.config";
 import { createReader } from "@keystatic/core/reader";
+import getPageMeta from "@/app/utils/getPageMeta";
+import type { Metadata } from "next";
+
+export function generateMetadata(): Metadata {
+   return getPageMeta("/blog");
+}
 
 const reader = createReader(process.cwd(), keystaticConfig);
 const BlogList = async () => {

--- a/app/(pages)/contact/page.tsx
+++ b/app/(pages)/contact/page.tsx
@@ -2,6 +2,12 @@ import BreadCrumb from "@/app/components/common/BreadCrumb";
 import ContactForm from "@/app/components/contact";
 import ContactMap from "@/app/components/contact/ContactMap";
 import { CtaNoSSR } from "@/app/page";
+import getPageMeta from "@/app/utils/getPageMeta";
+import type { Metadata } from "next";
+
+export function generateMetadata(): Metadata {
+   return getPageMeta("/contact");
+}
 
 export default function Contact() {
    return (

--- a/app/(pages)/privacy-policy/page.tsx
+++ b/app/(pages)/privacy-policy/page.tsx
@@ -1,5 +1,11 @@
 import BreadCrumb from "@/app/components/common/BreadCrumb";
 import './style.css';
+import getPageMeta from "@/app/utils/getPageMeta";
+import type { Metadata } from "next";
+
+export function generateMetadata(): Metadata {
+   return getPageMeta("/privacy-policy");
+}
 
 export default function PrivacyPolicy() {
    return (

--- a/app/(pages)/projects/[slug]/page.tsx
+++ b/app/(pages)/projects/[slug]/page.tsx
@@ -2,6 +2,12 @@ import BreadCrumb from "@/app/components/common/BreadCrumb";
 import Button from "@/app/components/common/Button";
 import readLocalFile from "@/app/utils/readLocalFile";
 import Image from "next/image";
+import getPageMeta from "@/app/utils/getPageMeta";
+import type { Metadata } from "next";
+
+export function generateMetadata({ params }: { params: { slug: string } }): Metadata {
+   return getPageMeta(`/projects/${params.slug}`);
+}
 
 interface ProjectFieldsType {
    title: string;

--- a/app/(pages)/projects/page.tsx
+++ b/app/(pages)/projects/page.tsx
@@ -1,6 +1,12 @@
 import BreadCrumb from '@/app/components/common/BreadCrumb'
 import ProjectList from '@/app/components/projects/ProjectList'
 import React from 'react'
+import getPageMeta from '@/app/utils/getPageMeta'
+import type { Metadata } from 'next'
+
+export function generateMetadata(): Metadata {
+  return getPageMeta('/projects');
+}
 
 export default function ProjectArchive() {
   return (

--- a/app/(pages)/services/[slug]/page.tsx
+++ b/app/(pages)/services/[slug]/page.tsx
@@ -2,6 +2,12 @@ import BreadCrumb from "@/app/components/common/BreadCrumb";
 import ServiceDetailsInfo from "@/app/components/serviceDetails";
 import { CtaNoSSR } from "@/app/page";
 import getServicesMeta from "@/app/utils/getServicesMeta";
+import getPageMeta from "@/app/utils/getPageMeta";
+import type { Metadata } from "next";
+
+export function generateMetadata({ params }: { params: { slug: string } }): Metadata {
+   return getPageMeta(`/services/${params.slug}`);
+}
 
 export async function generateStaticParams() {
    const services = getServicesMeta("/app/data/services");

--- a/app/(pages)/services/page.tsx
+++ b/app/(pages)/services/page.tsx
@@ -2,6 +2,12 @@ import BreadCrumb from "@/app/components/common/BreadCrumb";
 import AboutService from "@/app/components/services/aboutService";
 import ServiceMain from "@/app/components/services/mainServices";
 import dynamic from "next/dynamic";
+import getPageMeta from "@/app/utils/getPageMeta";
+import type { Metadata } from "next";
+
+export function generateMetadata(): Metadata {
+   return getPageMeta("/services");
+}
 
 const FaqNoSSR = dynamic(() => import("@/app/components/services/faq"), {
    ssr: false,

--- a/app/(pages)/terms-conditions/page.tsx
+++ b/app/(pages)/terms-conditions/page.tsx
@@ -1,5 +1,11 @@
 import BreadCrumb from "@/app/components/common/BreadCrumb";
 import "./style.css";
+import getPageMeta from "@/app/utils/getPageMeta";
+import type { Metadata } from "next";
+
+export function generateMetadata(): Metadata {
+   return getPageMeta("/terms-conditions");
+}
 
 export default function TermsCondition() {
    return (

--- a/app/data/meta.json
+++ b/app/data/meta.json
@@ -1,0 +1,98 @@
+{
+  "/": {
+    "title": "Custom Software Development Agency | SofGent",
+    "description": "SofGent is a results-driven custom software development agency offering scalable, secure, and tailored digital solutions. Build smarter with adaptive software today."
+  },
+  "/about": {
+    "title": "About SofGent | Trusted Custom Software Partner",
+    "description": "Learn about SofGent’s mission, team, and commitment to delivering innovative, scalable AI software solutions with a focus on quality, agility, and client success."
+  },
+  "/services": {
+    "title": "Enterprise Software Development Services | Sofgent",
+    "description": "Explore SofGent’s wide range of Enterprise Software Development Services including custom software, AI solutions, SaaS development, DevOps, testing."
+  },
+  "/projects": {
+    "title": "Our Projects | Custom AI Software Solutions Delivered",
+    "description": "Browse successful case studies and software projects delivered by SofGent. From SaaS platforms to AI Software Solutions, see how we solve real business challenges."
+  },
+  "/blog": {
+    "title": "Tech Insights & Software Trends Blog | SofGent",
+    "description": "Stay updated with the latest in software development, DevOps, AI, and agile practices. Read expert tips, industry insights, and thought leadership from SofGent."
+  },
+  "/contact": {
+    "title": "Contact SofGent | Start Your AI Driven Solutions",
+    "description": "Have a software idea or project? Contact SofGent today for a consultation. Let’s build secure, scalable, and tailored AI Driven Solutions together."
+  },
+  "/services/custom-software-development": {
+    "title": "Custom Software Development Services | Scalable Solutions",
+    "description": "Get bespoke software built for your unique needs. SofGent develops adaptive software development which is scalable, and secure."
+  },
+  "/services/devops-deployment-continuous-delivery": {
+    "title": "cloud devops consulting services & CI/CD Services | Faster, Reliable Deployments",
+    "description": "Optimize your software lifecycle with SofGent’s cloud devops consulting services. Accelerate development and reduce deployment risks."
+  },
+  "/services/advanced-ai-solutions": {
+    "title": "Advanced AI solutions company | SofGent Software Solution",
+    "description": "Unlock business growth with the best AI solutions company. SofGent offers AI-powered solutions including automation, analytics, and intelligent decision systems tailored to your goals."
+  },
+  "/services/saas-micro-saas-solutions": {
+    "title": "Cloud based saas Company | SofGent",
+    "description": "Build and scale your SaaS product with SofGent. We specialize in cloud-based SaaS and Micro-SaaS platforms tailored for innovation and growth."
+  },
+  "/privacy-policy": {
+    "title": "Privacy Policy | SofGent",
+    "description": "Review how SofGent collects, uses, and protects your data. We’re committed to transparency and safeguarding your privacy."
+  },
+  "/terms-conditions": {
+    "title": "Terms & Conditions | SofGent",
+    "description": "Read the terms and conditions for using SofGent’s services and website. Understand your rights and responsibilities."
+  },
+  "/services/net-core-api-clean-architecture-design-services": {
+    "title": ".NET Core API & Clean Architecture Services | SofGent",
+    "description": "Develop clean, scalable, and maintainable applications using .NET Core. SofGent offers modern architecture solutions tailored to enterprise needs."
+  },
+  "/services/software-testing": {
+    "title": "Software Testing & QA automation services | SofGent",
+    "description": "Ensure software quality with our end-to-end testing services. From manual QA to QA automation services, SofGent ensures reliable and bug-free solutions."
+  },
+  "/services/system-integration": {
+    "title": "System Integration management system| SofGent",
+    "description": "Connect and streamline your IT systems with SofGent. We deliver a secure and seamless system integration management system for improved data flow and performance."
+  },
+  "/services/system-maintenance": {
+    "title": "Software maintenance management system | SofGent",
+    "description": "Keep your software running smoothly with a proactive maintenance management system by SofGent. Ensure stability, security, and performance at all times."
+  },
+  "/projects/personal-portfolio": {
+    "title": "Custom UI/UX & Development | SofGent",
+    "description": "Explore our personal portfolio project showcasing modern UI/UX, responsive design, and custom frontend-backend development with clean architecture."
+  },
+  "/projects/personal-portfolio2": {
+    "title": "custom web application development company | SofGent",
+    "description": "See how SofGent built a creative personal portfolio using full-stack development, custom components, and seamless performance optimization."
+  },
+  "/projects/personal-portfolio3": {
+    "title": "Developer Portfolio Showcase | SofGent",
+    "description": "A developer-focused portfolio project built with clean code structure, interactive UI, and optimized performance to reflect best coding practices."
+  },
+  "/services/privacy-policy": {
+    "title": "Privacy Policy for Services | SofGent",
+    "description": "Understand how SofGent handles your data securely when you use our software development services. We prioritize your privacy and compliance."
+  },
+  "/services/terms-conditions": {
+    "title": "Terms & Conditions for Services | SofGent",
+    "description": "Read the terms governing the use of SofGent’s services including software development, DevOps, and AI solutions. Transparency you can trust."
+  },
+  "/projects/www.google.com": {
+    "title": "",
+    "description": ""
+  },
+  "/projects/privacy-policy": {
+    "title": "Privacy-Centric Software Project | SofGent",
+    "description": "This project emphasizes privacy-first architecture with compliance-driven design, secure storage, and responsible data handling practices."
+  },
+  "/projects/terms-conditions": {
+    "title": "Legal-Focused Software Project | SofGent",
+    "description": "A software solution centered on managing terms, policies, and user agreements—designed for flexibility, version control, and legal compliance."
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,12 @@ import Expertise from "./components/home/expertise";
 import WhyChooseUs from "./components/home/whyChooseUs";
 import Header from "./components/Layout/Header/Header";
 import Footer from "./components/Layout/Footer/Footer";
+import getPageMeta from "@/app/utils/getPageMeta";
+import type { Metadata } from "next";
+
+export function generateMetadata(): Metadata {
+  return getPageMeta("/");
+}
 
 export const CtaNoSSR = dynamic(() => import("@components/home/cta"), {
    ssr: false,

--- a/app/utils/getPageMeta.ts
+++ b/app/utils/getPageMeta.ts
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import metaMap from "@/app/data/meta.json";
+
+const defaultMeta: Metadata = {
+  title: "SofGent",
+  description: "Software IT Company",
+};
+
+export default function getPageMeta(path: string): Metadata {
+  const meta = (metaMap as Record<string, Metadata>)[path];
+  if (meta && typeof meta === "object") {
+    return meta;
+  }
+  return defaultMeta;
+}


### PR DESCRIPTION
## Summary
- centralize metadata in `meta.json`
- add helper to read metadata
- update pages to use metadata helper

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm ci` *(fails: network restricted)*

------
https://chatgpt.com/codex/tasks/task_e_6876435a8cc48333a24b2c38e6433ca2