### PR TITLE
Improve mobile layout and update hero

### DIFF
--- a/app/components/Layout/Footer/Footer.tsx
+++ b/app/components/Layout/Footer/Footer.tsx
@@ -93,7 +93,7 @@ export default function Footer() {
                </div>
             </div>
             {/* Services */}
-            <div className="col-span-3">
+            <div className="col-span-4 md:col-span-3">
                <h1 className="font-semibold text-white text-18">Services</h1>
                <ul className="mt-3.5">
                   {serviceList.map((service, index) => (
@@ -125,7 +125,7 @@ export default function Footer() {
                </ul>
             </div>
             {/* Quick Link */}
-            <div className="col-span-2">
+            <div className="col-span-4 md:col-span-2">
                <h1 className="font-semibold text-white text-18">Quick Link</h1>
                <ul className="mt-3.5">
                   {quickLinks.map((service, index) => (
@@ -157,7 +157,7 @@ export default function Footer() {
                </ul>
             </div>
             {/* Address */}
-            <div className="col-span-3">
+            <div className="col-span-4 md:col-span-3">
                <h1 className="font-semibold text-white text-18">Address</h1>
                <div className="flex gap-2 items-center relative group font-medium text-white/50 hover:text-white hover:underline transition-all duration-300 mt-3.5">
                   <span className="transition-all duration-300">

--- a/app/components/Layout/Header/Header.tsx
+++ b/app/components/Layout/Header/Header.tsx
@@ -1,11 +1,72 @@
+import { useState } from "react";
 import logo from "@assets/images/sofgent-logo.svg";
 import Image from "next/image";
 import Link from "next/link";
 import Topbar from "./Topbar";
 
 const Header = () => {
+   const [open, setOpen] = useState(false);
+
+   const navItems = [
+      { href: "/", label: "Home" },
+      { href: "/about", label: "About" },
+      { href: "/services", label: "Services" },
+      { href: "/projects", label: "Projects" },
+      { href: "/blog", label: "Blog" },
+      { href: "/contact", label: "Contact" },
+   ];
+
    return (
       <header>
+         {/* Mobile Header */}
+         <div className="fixed top-0 left-0 z-40 w-full bg-white border-b border-[#e7e8e9] xl:hidden">
+            <div className="flex items-center justify-between h-[60px] px-4">
+               <Link href="/" aria-label="logo">
+                  <Image width={160} height={40} src={logo} alt="SoftGen Logo" />
+               </Link>
+               <button
+                  aria-label="Toggle menu"
+                  onClick={() => setOpen(!open)}
+                  className="text-brand"
+               >
+                  <svg
+                     xmlns="http://www.w3.org/2000/svg"
+                     fill="none"
+                     viewBox="0 0 24 24"
+                     strokeWidth={1.5}
+                     stroke="currentColor"
+                     className="w-7 h-7"
+                  >
+                     {open ? (
+                        <path
+                           strokeLinecap="round"
+                           strokeLinejoin="round"
+                           d="M6 18L18 6M6 6l12 12"
+                        />
+                     ) : (
+                        <path
+                           strokeLinecap="round"
+                           strokeLinejoin="round"
+                           d="M3.75 9h16.5m-16.5 6.75h16.5"
+                        />
+                     )}
+                  </svg>
+               </button>
+            </div>
+            {open && (
+               <ul className="flex flex-col px-4 pb-4 space-y-2">
+                  {navItems.map((item) => (
+                     <li key={item.href} className="font-semibold text-paragraph">
+                        <Link href={item.href} onClick={() => setOpen(false)}>
+                           {item.label}
+                        </Link>
+                     </li>
+                  ))}
+               </ul>
+            )}
+         </div>
+
+         {/* Desktop Header */}
          <div className="fixed top-0 left-0 z-40 hidden w-full header-wrapper xl:block h1-header-sticky h1-header-sticky-qs">
             <div className="2xl:px-[110px] px-5 mx-auto relative">
                <Topbar />
@@ -23,24 +84,11 @@ const Header = () => {
                      </div>
                      <div className="w-2/4">
                         <ul className="flex items-center space-x-10">
-                           <li className="font-semibold text-paragraph hover:underline hover:text-brand">
-                              <Link href="/">Home</Link>
-                           </li>
-                           <li className="font-semibold text-paragraph hover:underline hover:text-brand">
-                              <Link href="/about">About</Link>
-                           </li>
-                           <li className="font-semibold text-paragraph hover:underline hover:text-brand">
-                              <Link href="/services">Services</Link>
-                           </li>
-                           <li className="font-semibold text-paragraph hover:underline hover:text-brand">
-                              <Link href="/projects">Projects</Link>
-                           </li>
-                           <li className="font-semibold text-paragraph hover:underline hover:text-brand">
-                              <Link href="/blog">Blog</Link>
-                           </li>
-                           <li className="font-semibold text-paragraph hover:underline hover:text-brand">
-                              <Link href="/contact">Contact</Link>
-                           </li>
+                           {navItems.map((item) => (
+                              <li key={item.href} className="font-semibold text-paragraph hover:underline hover:text-brand">
+                                 <Link href={item.href}>{item.label}</Link>
+                              </li>
+                           ))}
                         </ul>
                      </div>
                   </div>

--- a/app/components/Layout/Header/Topbar.tsx
+++ b/app/components/Layout/Header/Topbar.tsx
@@ -1,6 +1,6 @@
 export default function Topbar() {
    return (
-      <div className="w-full bg-gradient-to-r from-gray to-brand h-[45px] justify-between items-center pl-[50px] bg-white border border-[#e7e8e9] hidden h1-top-bar">
+      <div className="w-full bg-gradient-to-r from-gray to-brand h-[45px] justify-between items-center pl-[50px] bg-white border border-[#e7e8e9] hidden xl:flex">
          <span className="hidden 2xl:block">
             Welcome to
             <span className="font-semibold text-brand"> SofGent</span>

--- a/app/components/home/hero/index.tsx
+++ b/app/components/home/hero/index.tsx
@@ -73,14 +73,13 @@ export default function Hero() {
                 </span>
               </div>
               <h2 className="text-4xl md:text-[56px] leading-normal text-main-black font-semibold mb-[35px] pointer-events-auto">
-                <span>Crafting High </span> <br />
-                <span>Performance </span>
+                <span>Building </span>
                 <span className="relative inline-block px-3 font-bold text-white uppercase">
-                  <span className="relative z-10">SaaS</span>
+                  <span className="relative z-10">Modern</span>
                   <span className="absolute top-0 left-0 block w-full h-full bg-gradient-to-r from-brand"></span>
                 </span>
                 <br />
-                <span className="italic"> Solutions for Tomorrow </span>
+                <span>SaaS Solutions for Growth</span>
               </h2>
               <div className="px-6 py-[14px] bg-white border-l-2 border-brand mb-[35px] pointer-events-auto xl:w-full md:w-[500px]">
                 <p className="text-ptwo text-paragraph">


### PR DESCRIPTION
## Summary
- add mobile menu to header
- tweak Topbar visibility
- modernize hero text
- make footer grid responsive

## Testing
- `npm install` *(fails: internet disabled)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876483b183483339c58efddf4df9261